### PR TITLE
Fix automation for untar'ing xz files on linux

### DIFF
--- a/.github/workflows/periodic-update-multitool.yml
+++ b/.github/workflows/periodic-update-multitool.yml
@@ -27,7 +27,7 @@ jobs:
         run: |
           latest="$(curl https://api.github.com/repos/theoremlp/multitool/releases/latest | jq -r '.assets[].browser_download_url | select(. | test("linux-gnu.tar.xz$"))')"
           wget -O multitool.tar.xz "$latest"
-          tar --strip-components=1 -xzf multitool.tar.xz
+          tar --strip-components=1 -xf multitool.tar.xz
       - name: Find Updates and Render Lockfile
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
Errantly included a `-z` (which functions on macos but not on linux)
