### PR TITLE
Add reviewbot and renovate automation

### DIFF
--- a/.github/renovate-config.json
+++ b/.github/renovate-config.json
@@ -1,0 +1,9 @@
+{
+  "branchPrefix": "renovate/",
+  "username": "renovate-thm[bot]",
+  "gitAuthor": "renovate <renovate-thm[bot]@users.noreply.github.com>",
+  "platform": "github",
+  "onboarding": false,
+  "forkProcessing": "disabled",
+  "repositories": ["theoremlp/rules_uv"]
+}

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,18 +1,16 @@
 {
-    "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-    "extends": [
-      ":dependencyDashboard",
-      ":semanticPrefixFixDepsChoreOthers",
-      "group:monorepos",
-      "group:recommended",
-      "replacements:all",
-      "workarounds:all"
-    ],
-    "packageRules": [
-      {
-        "matchFiles": ["MODULE.bazel"],
-        "enabled": false
-      }
-    ]
-  }
-  
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [":semanticCommitsDisabled"],
+  "enabledManagers": ["github-actions"],
+  "timezone": "America/New_York",
+  "schedule": ["every weekday after 9am before 5pm"],
+  "branchConcurrentLimit": 10,
+  "labels": ["automerge"],
+  "dependencyDashboard": true,
+  "packageRules": [
+    {
+      "matchFiles": ["MODULE.bazel"],
+      "enabled": false
+    }
+  ]
+}

--- a/.github/reviewers.json
+++ b/.github/reviewers.json
@@ -1,0 +1,14 @@
+{
+  "teams": {},
+  "reviewers": {},
+  "overrides": [
+    {
+      "description": "Auto-approve automated PRs",
+      "onlyModifiedByUsers": ["thm-automation[bot]", "renovate-thm[bot]"],
+      "onlyModifiedFileRegExs": [
+        "^.github/workflows/.*",
+        "^uv/private/uv.lock.json$"
+      ]
+    }
+  ]
+}

--- a/.github/workflows/automation-reviewbot.yml
+++ b/.github/workflows/automation-reviewbot.yml
@@ -1,0 +1,14 @@
+name: reviewbot
+on:
+  pull_request: {}
+  pull_request_review: {}
+jobs:
+  required-reviewers:
+    name: reviewbot
+    runs-on: ubuntu-latest
+    steps:
+      - name: required-reviewers
+        uses: theoremlp/required-reviews@v2
+        with:
+          github-token: ${{ secrets.REVIEW_TOKEN_PUB }}
+          post-review: true

--- a/.github/workflows/periodic-renovate.yml
+++ b/.github/workflows/periodic-renovate.yml
@@ -1,0 +1,24 @@
+name: Renovate
+on:
+  workflow_dispatch: {}
+  schedule:
+    # run every 15th minute between 9am and 5pm (4am and 12pm UTC), M-F
+    - cron: "0/15 14-22 * * 1-5"
+jobs:
+  renovate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get Renovate GitHub App Token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.RENOVATE_THM_APP_ID_PUB }}
+          private-key: ${{ secrets.RENOVATE_THM_PRIVATE_KEY_PUB }}
+      - uses: actions/checkout@v4
+      - name: Run Renovate
+        uses: renovatebot/github-action@2e021d24483d81e77e0e902d0809adfbfff276fc # v40.1.10
+        with:
+          # options in this file are defined by
+          # https://docs.renovatebot.com/self-hosted-configuration/
+          configurationFile: .github/renovate-config.json
+          token: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
Add reviewbot and renovate actions to automate approvals of automation PRs and to create automation PRs, respectively. Renovate is configured only to update GitHub actions -- we wish to maintain long backwards compatibility in our MODULE.bazel by using minimum versions.
