### PR TITLE
Add autorelease automation

### DIFF
--- a/.github/workflows/automation-autorelease.yml
+++ b/.github/workflows/automation-autorelease.yml
@@ -1,0 +1,22 @@
+name: autorelease
+on:
+  schedule:
+    # check at 11am every day
+    - cron: "0 11 * * *"
+jobs:
+  autorelease:
+    name: autorelease
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get Token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.THM_AUTOMATION_APP_ID }}
+          private-key: ${{ secrets.THM_AUTOMATION_PRIVATE_KEY }}
+      - name: autorelease
+        uses: markelliot/autorelease@v2
+        with:
+          github-token: ${{ steps.app-token.outputs.token }}
+          max-days: 7
+          tag-only: true

--- a/.github/workflows/automation-autorelease.yml
+++ b/.github/workflows/automation-autorelease.yml
@@ -1,5 +1,6 @@
 name: autorelease
 on:
+  workflow_dispatch: {}
   schedule:
     # check at 11am every day
     - cron: "0 11 * * *"
@@ -7,6 +8,7 @@ jobs:
   autorelease:
     name: autorelease
     runs-on: ubuntu-latest
+    if: ${{ github.ref == 'refs/heads/main' }}
     steps:
       - name: Get Token
         id: app-token

--- a/.github/workflows/periodic-renovate.yml
+++ b/.github/workflows/periodic-renovate.yml
@@ -7,6 +7,7 @@ on:
 jobs:
   renovate:
     runs-on: ubuntu-latest
+    if: ${{ github.ref == 'refs/heads/main' }}
     steps:
       - name: Get Renovate GitHub App Token
         id: app-token


### PR DESCRIPTION
Now that rules_uv has automation to update the underlying version of uv, add autorelease automation that will create a tag if there have been commits and at least 7 days since the last release.
