### PR TITLE
Add '--no-strip-extras' to uv pip calls

### DIFF
--- a/uv/private/pip_compile.sh
+++ b/uv/private/pip_compile.sh
@@ -18,6 +18,7 @@ PYTHON_VERSION="$(python3 -c 'import sys; print(f"{sys.version_info.major}.{sys.
 $UV pip compile \
     --generate-hashes \
     --no-header \
+    --no-strip-extras \
     --python-version=$PYTHON_VERSION \
     -o $REQUIREMENTS_TXT \
     $REQUIREMENTS_IN \

--- a/uv/private/pip_compile_test.sh
+++ b/uv/private/pip_compile_test.sh
@@ -19,6 +19,7 @@ $UV pip compile \
     --no-cache \
     --generate-hashes \
     --no-header \
+    --no-strip-extras \
     --python-version=$PYTHON_VERSION \
     -c $REQUIREMENTS_TXT \
     $REQUIREMENTS_IN


### PR DESCRIPTION
Better match pip-compile's behavior.
