### PR TITLE
Only run automation steps in the repo

### DIFF
--- a/.github/workflows/automation-autosquash.yml
+++ b/.github/workflows/automation-autosquash.yml
@@ -20,13 +20,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Get Token
+        if: ${{ github.repository_owner == 'theoremlp' }}
         id: app-token
         uses: actions/create-github-app-token@v1
         with:
           app-id: ${{ secrets.THM_AUTOMATION_APP_ID }}
           private-key: ${{ secrets.THM_AUTOMATION_PRIVATE_KEY }}
-      - uses: actions/checkout@v4
-      - uses: theoremlp/autosquash@v1
+      - if: ${{ github.repository_owner == 'theoremlp' }}
+        uses: actions/checkout@v4
+      - if: ${{ github.repository_owner == 'theoremlp' }}
+        uses: theoremlp/autosquash@v1
         with:
           github-token: ${{ steps.app-token.outputs.token }}
           pull-request-number: ${{ github.event.pull_request.number }}

--- a/.github/workflows/automation-reviewbot.yml
+++ b/.github/workflows/automation-reviewbot.yml
@@ -6,6 +6,7 @@ jobs:
   required-reviewers:
     name: reviewbot
     runs-on: ubuntu-latest
+    if: ${{ github.repository_owner == 'theoremlp' }}
     steps:
       - name: required-reviewers
         uses: theoremlp/required-reviews@v2


### PR DESCRIPTION
In #23 we had our first external contribution and reviewbot and autosquash automation failed because of secrets access. We don't need either of these to run on external contributions, so limit running them to just the primary repo. Note that autosquash has to have its steps suppressed rather than the task because it's a required action (and needs to be a required action to function).