### PR TITLE
Fix tag composition

### DIFF
--- a/uv/private/pip.bzl
+++ b/uv/private/pip.bzl
@@ -72,6 +72,8 @@ _pip_compile_test = rule(
 )
 
 def pip_compile(name, requirements_in = None, requirements_txt = None, target_compatible_with = None, python_platform = None, tags = None):
+    tags = tags or []
+
     _pip_compile(
         name = name,
         requirements_in = requirements_in or "//:requirements.in",
@@ -86,5 +88,5 @@ def pip_compile(name, requirements_in = None, requirements_txt = None, target_co
         requirements_txt = requirements_txt or "//:requirements.txt",
         python_platform = python_platform or "",
         target_compatible_with = target_compatible_with,
-        tags = ["requires-network"] + tags if tags else [],
+        tags = ["requires-network"] + tags,
     )


### PR DESCRIPTION
In #23 the tag composition expression resulted in dropping ["requires-network"] when tags are absent.