### PR TITLE
pass --emit-index-url to 'uv pip compile'

### DIFF
--- a/uv/private/pip_compile.sh
+++ b/uv/private/pip_compile.sh
@@ -18,6 +18,7 @@ PYTHON_VERSION="$(python3 -c 'import sys; print(f"{sys.version_info.major}.{sys.
 
 $UV pip compile \
     --generate-hashes \
+    --emit-index-url \
     --no-header \
     --no-strip-extras \
     --python-version=$PYTHON_VERSION \

--- a/uv/private/pip_compile_test.sh
+++ b/uv/private/pip_compile_test.sh
@@ -19,6 +19,7 @@ PYTHON_VERSION="$(python3 -c 'import sys; print(f"{sys.version_info.major}.{sys.
 $UV pip compile \
     --no-cache \
     --generate-hashes \
+    --emit-index-url \
     --no-header \
     --no-strip-extras \
     --python-version=$PYTHON_VERSION \


### PR DESCRIPTION
... for integration with private registries/indexes

I know that we can also pass `extra_pip_args` in any `pip_parse` repo rules, but this seemed like it might be a nice default behavior to have. I couldn't find any pass discussion of this in the repo.
