### PR TITLE
Fix pip_compile_test

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,3 +1,5 @@
 common --enable_bzlmod
 
 common --lockfile_mode=off
+
+test --test_output=errors

--- a/examples/typical/.bazelrc
+++ b/examples/typical/.bazelrc
@@ -1,3 +1,5 @@
 common --enable_bzlmod
 
 common --lockfile_mode=off
+
+test --test_output=errors

--- a/examples/typical/requirements.txt
+++ b/examples/typical/requirements.txt
@@ -1,3 +1,4 @@
 click==8.1.7 \
     --hash=sha256:ae74fb96c20a0277a1d615f1e4d73c8414f5a98db8b799a7931d1582f3390c28 \
     --hash=sha256:ca9853ad459e787e2192211578cc907e7594e294c7ccc834310722b41b9ca6de
+    # via -r requirements.in

--- a/examples/typical/requirements.txt
+++ b/examples/typical/requirements.txt
@@ -1,3 +1,5 @@
+--index-url https://pypi.org/simple
+
 click==8.1.7 \
     --hash=sha256:ae74fb96c20a0277a1d615f1e4d73c8414f5a98db8b799a7931d1582f3390c28 \
     --hash=sha256:ca9853ad459e787e2192211578cc907e7594e294c7ccc834310722b41b9ca6de

--- a/examples/typical/requirements_linux.txt
+++ b/examples/typical/requirements_linux.txt
@@ -1,3 +1,4 @@
 click==8.1.7 \
     --hash=sha256:ae74fb96c20a0277a1d615f1e4d73c8414f5a98db8b799a7931d1582f3390c28 \
     --hash=sha256:ca9853ad459e787e2192211578cc907e7594e294c7ccc834310722b41b9ca6de
+    # via -r requirements.in

--- a/examples/typical/requirements_linux.txt
+++ b/examples/typical/requirements_linux.txt
@@ -1,3 +1,5 @@
+--index-url https://pypi.org/simple
+
 click==8.1.7 \
     --hash=sha256:ae74fb96c20a0277a1d615f1e4d73c8414f5a98db8b799a7931d1582f3390c28 \
     --hash=sha256:ca9853ad459e787e2192211578cc907e7594e294c7ccc834310722b41b9ca6de

--- a/uv/private/pip_compile_test.sh
+++ b/uv/private/pip_compile_test.sh
@@ -13,10 +13,14 @@ RESOLVED_PYTHON_BIN="$(dirname "$RESOLVED_PYTHON")"
 # set resolved python to front of the path
 export PATH="$RESOLVED_PYTHON_BIN:$PATH"
 
+# make a writable copy of incoming requirements
+cp "$REQUIREMENTS_TXT" __updated__
+
 # get the version of python to hand to uv pip compile
 PYTHON_VERSION="$(python3 -c 'import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}")')"
 
 $UV pip compile \
+    --quiet \
     --no-cache \
     --generate-hashes \
     --emit-index-url \
@@ -24,5 +28,12 @@ $UV pip compile \
     --no-strip-extras \
     --python-version=$PYTHON_VERSION \
     $(echo $PYTHON_PLATFORM) \
-    -c $REQUIREMENTS_TXT \
+    -o __updated__ \
     $REQUIREMENTS_IN
+
+# check files match
+if ! diff "$REQUIREMENTS_TXT" "__updated__" > /dev/null
+then
+  echo >&2 "FAIL: $REQUIREMENTS_TXT needs to be re-generated."
+  exit 1
+fi


### PR DESCRIPTION
Update `pip_compile_test` to fail on any textual differences in requirements txt output. Prior to this PR, it checked the constraints were satisfied but not that the precise formatting matched. After this PR, any textual output differences will fail the test.