### PR TITLE
Suppress reviewbot on individual job items

### DIFF
--- a/.github/workflows/automation-reviewbot.yml
+++ b/.github/workflows/automation-reviewbot.yml
@@ -6,9 +6,9 @@ jobs:
   required-reviewers:
     name: reviewbot
     runs-on: ubuntu-latest
-    if: ${{ github.repository_owner == 'theoremlp' }}
     steps:
       - name: required-reviewers
+        if: ${{ github.repository_owner == 'theoremlp' }}
         uses: theoremlp/required-reviews@v2
         with:
           github-token: ${{ secrets.REVIEW_TOKEN_PUB }}


### PR DESCRIPTION
We're trying to get reviewbot not to fail on contributions from a fork -- the prior attempt in #25 didn't seem to do the trick.
