### PR TITLE
Further suppress reviewbot in 3rd party repos

### DIFF
--- a/.github/workflows/automation-reviewbot.yml
+++ b/.github/workflows/automation-reviewbot.yml
@@ -6,10 +6,10 @@ jobs:
   required-reviewers:
     name: reviewbot
     runs-on: ubuntu-latest
+    if: ${{ github.repository_owner == 'theoremlp' }}
     steps:
       - name: required-reviewers
-        if: ${{ github.repository_owner == 'theoremlp' }}
         uses: theoremlp/required-reviews@v2
         with:
-          github-token: ${{ secrets.REVIEW_TOKEN_PUB }}
+          github-token: ${{ secrets.REVIEW_TOKEN_PUB || '' }}
           post-review: true


### PR DESCRIPTION
## Issue
In #25 and #34 we've been trying to make it so that reviewbot doesn't fail when submissions come from 3rd party repos. #34 moved the suppression from the job to the step, but we still see a failure in #35 -- reading the failure more closely it seems to be because the secret is absent and the action validator still runs.

## Summary
Add an alternate value to the reviewbot secret to help pass validation and move the suppression back to the job.