### PR TITLE
Use full name of repository to suppress runs for forks

### DIFF
--- a/.github/workflows/automation-autosquash.yml
+++ b/.github/workflows/automation-autosquash.yml
@@ -20,15 +20,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Get Token
-        if: github.repository == 'theoremlp/rules_uv'
+        if: github.event.pull_request.head.repo.full_name == 'theoremlp/rules_uv'
         id: app-token
         uses: actions/create-github-app-token@v1
         with:
           app-id: ${{ secrets.THM_AUTOMATION_APP_ID }}
           private-key: ${{ secrets.THM_AUTOMATION_PRIVATE_KEY }}
-      - if: github.repository == 'theoremlp/rules_uv'
+      - if: github.event.pull_request.head.repo.full_name == 'theoremlp/rules_uv'
         uses: actions/checkout@v4
-      - if: github.repository == 'theoremlp/rules_uv'
+      - if: github.event.pull_request.head.repo.full_name == 'theoremlp/rules_uv'
         uses: theoremlp/autosquash@v1
         with:
           github-token: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/automation-autosquash.yml
+++ b/.github/workflows/automation-autosquash.yml
@@ -20,15 +20,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Get Token
-        if: ${{ github.repository_owner == 'theoremlp' }}
+        if: github.repository == 'theoremlp/rules_uv'
         id: app-token
         uses: actions/create-github-app-token@v1
         with:
           app-id: ${{ secrets.THM_AUTOMATION_APP_ID }}
           private-key: ${{ secrets.THM_AUTOMATION_PRIVATE_KEY }}
-      - if: ${{ github.repository_owner == 'theoremlp' }}
+      - if: github.repository == 'theoremlp/rules_uv'
         uses: actions/checkout@v4
-      - if: ${{ github.repository_owner == 'theoremlp' }}
+      - if: github.repository == 'theoremlp/rules_uv'
         uses: theoremlp/autosquash@v1
         with:
           github-token: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/automation-reviewbot.yml
+++ b/.github/workflows/automation-reviewbot.yml
@@ -6,10 +6,10 @@ jobs:
   required-reviewers:
     name: reviewbot
     runs-on: ubuntu-latest
-    if: ${{ github.repository_owner == 'theoremlp' }}
+    if: github.repository == 'theoremlp/rules_uv'
     steps:
       - name: required-reviewers
         uses: theoremlp/required-reviews@v2
         with:
-          github-token: ${{ secrets.REVIEW_TOKEN_PUB || '' }}
+          github-token: ${{ secrets.REVIEW_TOKEN_PUB }}
           post-review: true

--- a/.github/workflows/automation-reviewbot.yml
+++ b/.github/workflows/automation-reviewbot.yml
@@ -6,7 +6,7 @@ jobs:
   required-reviewers:
     name: reviewbot
     runs-on: ubuntu-latest
-    if: github.repository == 'theoremlp/rules_uv'
+    if: github.event.pull_request.head.repo.full_name == 'theoremlp/rules_uv'
     steps:
       - name: required-reviewers
         uses: theoremlp/required-reviews@v2


### PR DESCRIPTION
In #36 (and prior) we were incorrectly using the `repository_owner`, when in fact the docs say we should use the full `repository` key to condition running jobs/steps.
