### PR TITLE
Remove dependency on rules_python

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -11,9 +11,6 @@ bazel_dep(name = "buildifier_prebuilt", version = "6.1.2")
 bazel_dep(name = "platforms", version = "0.0.8")
 bazel_dep(name = "rules_multitool", version = "0.4.0")
 
-# required for venv
-bazel_dep(name = "rules_python", version = "0.31.0")
-
 multitool = use_extension("@rules_multitool//multitool:extension.bzl", "multitool")
 multitool.hub(lockfile = "//uv/private:uv.lock.json")
 use_repo(multitool, "multitool")

--- a/examples/typical/MODULE.bazel
+++ b/examples/typical/MODULE.bazel
@@ -6,6 +6,7 @@ module(
 )
 
 bazel_dep(name = "platforms", version = "0.0.8")
+bazel_dep(name = "rules_python", version = "0.31.0")
 bazel_dep(name = "rules_uv", version = "0.0.0")
 local_path_override(
     module_name = "rules_uv",

--- a/readme.md
+++ b/readme.md
@@ -10,6 +10,12 @@ Installing with bzlmod, add to MODULE.bazel (adjust version as appropriate):
 bazel_dep(name = "rules_uv", version = "<version>")
 ```
 
+**Note**: rules_uv requires a Python toolchain to be available. One can be obtained by having [rules_python](https://github.com/bazelbuild/rules_python) installed using:
+
+```starlark
+bazel_dep(name = "rules_python", version = "<rules_python version>")
+```
+
 ### pip_compile
 
 Create a requirements.in or pyproject.toml -> requirements.txt compilation target and diff test:


### PR DESCRIPTION
## Issue

The rules_python maintainers would like to depend on rules_uv to re-publish the `pip_compile` macro, but there's some uncertainty around whether a circular dependency between rules_uv and rules_python would cause problems. rules_uv only depends on there existing a Python toolchain at execution time, and otherwise doesn't need the explicit dependency, so we can remove it.

## Summary

Remove the rules_python dependency from the main module and add it back in examples. Update the readme to help users continue to have a functioning ruleset.

