### PR TITLE
pip-compile: args

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -27,8 +27,13 @@ pip_compile(
     name = "generate_requirements_txt",
     requirements_in = "//:requirements.in", # default
     requirements_txt = "//:requirements.txt", # default
+    generate_hashes = True, # default
+    emit_index_url = True, # default
+    no_strip_extras = True, # default
 )
 ```
+> [!NOTE]
+> You may also override the `--custom-compile-command` arg using the `custom_compile_command` kwarg.
 
 Run the compilation step with `bazel run //:generate_requirements_txt`.
 

--- a/uv/private/pip.bzl
+++ b/uv/private/pip.bzl
@@ -6,6 +6,10 @@ _common_attrs = {
     "requirements_in": attr.label(mandatory = True, allow_single_file = True),
     "requirements_txt": attr.label(mandatory = True, allow_single_file = True),
     "python_platform": attr.string(default = ""),
+    "generate_hashes": attr.bool(default = True),
+    "emit_index_url": attr.bool(default = True),
+    "no_strip_extras": attr.bool(default = True),
+    "custom_compile_command": attr.string(default = ""),
     "_uv": attr.label(default = "@multitool//tools/uv", executable = True, cfg = "exec"),
 }
 
@@ -13,6 +17,17 @@ def _python_platform(maybe_python_platform):
     if maybe_python_platform == "":
         return ""
     return "--python-platform {python_platform}".format(python_platform = maybe_python_platform)
+
+def _pip_compile_args(ctx):
+    custom_compile_command = ctx.attr.custom_compile_command or "bazel run {label}".format(label = ctx.label)
+    return " ".join(
+        [
+            "--generate-hashes" if ctx.attr.generate_hashes else "",
+            "--emit-index-url" if ctx.attr.emit_index_url else "",
+            "--no-strip-extras" if ctx.attr.no_strip_extras else "",
+            "--custom-compile-command \"{custom_compile_command}\"".format(custom_compile_command = custom_compile_command),
+        ],
+    )
 
 def _uv_pip_compile(ctx, template, executable, generator_label):
     py_toolchain = ctx.toolchains[_PY_TOOLCHAIN]
@@ -25,6 +40,7 @@ def _uv_pip_compile(ctx, template, executable, generator_label):
             "{{requirements_txt}}": ctx.file.requirements_txt.short_path,
             "{{resolved_python}}": py_toolchain.py3_runtime.interpreter.short_path,
             "{{python_platform}}": _python_platform(ctx.attr.python_platform),
+            "{{pip_compile_args}}": _pip_compile_args(ctx),
             "{{label}}": str(generator_label),
         },
     )
@@ -73,7 +89,18 @@ _pip_compile_test = rule(
     test = True,
 )
 
-def pip_compile(name, requirements_in = None, requirements_txt = None, target_compatible_with = None, python_platform = None, tags = None):
+def pip_compile(
+        name,
+        requirements_in = None,
+        requirements_txt = None,
+        target_compatible_with = None,
+        python_platform = None,
+        tags = None,
+        generate_hashes = False,
+        emit_index_url = False,
+        no_strip_extras = False,
+        custom_compile_command = None
+    ):
     tags = tags or []
 
     _pip_compile(
@@ -82,6 +109,10 @@ def pip_compile(name, requirements_in = None, requirements_txt = None, target_co
         requirements_txt = requirements_txt or "//:requirements.txt",
         python_platform = python_platform or "",
         target_compatible_with = target_compatible_with,
+        generate_hashes = generate_hashes,
+        emit_index_url = emit_index_url,
+        no_strip_extras = no_strip_extras,
+        custom_compile_command = custom_compile_command,
     )
 
     _pip_compile_test(
@@ -91,5 +122,9 @@ def pip_compile(name, requirements_in = None, requirements_txt = None, target_co
         requirements_txt = requirements_txt or "//:requirements.txt",
         python_platform = python_platform or "",
         target_compatible_with = target_compatible_with,
+        generate_hashes = generate_hashes,
+        emit_index_url = emit_index_url,
+        no_strip_extras = no_strip_extras,
+        custom_compile_command = custom_compile_command,
         tags = ["requires-network"] + tags,
     )

--- a/uv/private/pip.bzl
+++ b/uv/private/pip.bzl
@@ -96,9 +96,9 @@ def pip_compile(
         target_compatible_with = None,
         python_platform = None,
         tags = None,
-        generate_hashes = False,
-        emit_index_url = False,
-        no_strip_extras = False,
+        generate_hashes = True,
+        emit_index_url = True,
+        no_strip_extras = True,
         custom_compile_command = None
     ):
     tags = tags or []

--- a/uv/private/pip_compile.sh
+++ b/uv/private/pip_compile.sh
@@ -8,6 +8,7 @@ RESOLVED_PYTHON="{{resolved_python}}"
 REQUIREMENTS_IN="{{requirements_in}}"
 REQUIREMENTS_TXT="{{requirements_txt}}"
 LABEL="{{label}}"
+PIP_COMPILE_ARGS='{{pip_compile_args}}'
 
 RESOLVED_PYTHON_BIN="$(dirname "$RESOLVED_PYTHON")"
 
@@ -17,12 +18,8 @@ export PATH="$RESOLVED_PYTHON_BIN:$PATH"
 # get the version of python to hand to uv pip compile
 PYTHON_VERSION="$(python3 -c 'import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}")')"
 
-$UV pip compile \
-    --generate-hashes \
-    --emit-index-url \
-    --no-strip-extras \
-    --custom-compile-command "bazel run $LABEL" \
-    --python-version=$PYTHON_VERSION \
+eval $UV pip compile \
+    $PIP_COMPILE_ARGS \
     $(echo $PYTHON_PLATFORM) \
     -o $REQUIREMENTS_TXT \
     $REQUIREMENTS_IN \

--- a/uv/private/pip_compile_test.sh
+++ b/uv/private/pip_compile_test.sh
@@ -8,6 +8,7 @@ RESOLVED_PYTHON="{{resolved_python}}"
 REQUIREMENTS_IN="{{requirements_in}}"
 REQUIREMENTS_TXT="{{requirements_txt}}"
 LABEL="{{label}}"
+PIP_COMPILE_ARGS='{{pip_compile_args}}'
 
 RESOLVED_PYTHON_BIN="$(dirname "$RESOLVED_PYTHON")"
 
@@ -20,13 +21,9 @@ cp "$REQUIREMENTS_TXT" __updated__
 # get the version of python to hand to uv pip compile
 PYTHON_VERSION="$(python3 -c 'import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}")')"
 
-$UV pip compile \
+eval $UV pip compile \
     --quiet \
-    --no-cache \
-    --generate-hashes \
-    --emit-index-url \
-    --no-strip-extras \
-    --custom-compile-command "bazel run ${LABEL}" \
+    $PIP_COMPILE_ARGS \
     --python-version=$PYTHON_VERSION \
     $(echo $PYTHON_PLATFORM) \
     -o __updated__ \


### PR DESCRIPTION
### Summary

We would like to make the arguments into pip compile configurable for rules_uv.  Specifically:
- `--generate-hashes`
- `--emit-index-url`
- `--no-strip-extras`  
- `--custom-compile-command`

### Description of changes

- Updated docs
- Extracted the logic which parses args into `pip.bzl`.  
- In order for this to work correctly, had to use an eval for the `uv pip compile` command in both `pip_compile.sh` and `pip_compile_test.sh`

### Risks

There doesn't seem to be a lot of automated testing available using `bazel test`, so there may be edge cases I've missed.  Particularly with the changes to the bash scripts.

### Testing

Tested locally by extending the repo BUILD file with 
```starlark
load("//uv:pip.bzl", "pip_compile")

pip_compile(
    name = "generate_requirements_txt",
    generate_hashes = True,
    emit_index_url = False,
    no_strip_extras = False,
    custom_compile_command = "./bin/run_pip_compile",
)
```
and running `bazel run //:generate_requirements_txt`

Tested in a much larger private codebase using 
```starlark
git_override(
    module_name = "rules_uv",
    remote = "https://github.com/hugocarr/rules_uv",
    commit = "c479c2dcb9819ef8cfc4501a0660c993ad8ab4ec",
)
```
 and it works as expected for our usecase. 