### PR TITLE
Read the Python version from toolchain

### DIFF
--- a/uv/private/pip.bzl
+++ b/uv/private/pip.bzl
@@ -9,6 +9,12 @@ _common_attrs = {
     "_uv": attr.label(default = "@multitool//tools/uv", executable = True, cfg = "exec"),
 }
 
+def _python_version(py_toolchain):
+    return "{major}.{minor}".format(
+        major = py_toolchain.py3_runtime.interpreter_version_info.major,
+        minor = py_toolchain.py3_runtime.interpreter_version_info.minor,
+    )
+
 def _python_platform(maybe_python_platform):
     if maybe_python_platform == "":
         return ""
@@ -24,6 +30,7 @@ def _uv_pip_compile(ctx, template, executable, generator_label):
             "{{requirements_in}}": ctx.file.requirements_in.short_path,
             "{{requirements_txt}}": ctx.file.requirements_txt.short_path,
             "{{resolved_python}}": py_toolchain.py3_runtime.interpreter.short_path,
+            "{{python_version}}": _python_version(py_toolchain),
             "{{python_platform}}": _python_platform(ctx.attr.python_platform),
             "{{label}}": str(generator_label),
         },

--- a/uv/private/pip_compile.sh
+++ b/uv/private/pip_compile.sh
@@ -5,6 +5,7 @@ set -euo pipefail
 UV="{{uv}}"
 PYTHON_PLATFORM="{{python_platform}}"
 RESOLVED_PYTHON="{{resolved_python}}"
+PYTHON_VERSION="{{python_version}}"
 REQUIREMENTS_IN="{{requirements_in}}"
 REQUIREMENTS_TXT="{{requirements_txt}}"
 LABEL="{{label}}"
@@ -14,16 +15,13 @@ RESOLVED_PYTHON_BIN="$(dirname "$RESOLVED_PYTHON")"
 # set resolved python to front of the path
 export PATH="$RESOLVED_PYTHON_BIN:$PATH"
 
-# get the version of python to hand to uv pip compile
-PYTHON_VERSION="$(python3 -c 'import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}")')"
-
 $UV pip compile \
     --generate-hashes \
     --emit-index-url \
     --no-strip-extras \
     --custom-compile-command "bazel run $LABEL" \
-    --python-version=$PYTHON_VERSION \
+    --python-version="$PYTHON_VERSION" \
     $(echo $PYTHON_PLATFORM) \
-    -o $REQUIREMENTS_TXT \
-    $REQUIREMENTS_IN \
+    -o "$REQUIREMENTS_TXT" \
+    "$REQUIREMENTS_IN" \
     "$@"

--- a/uv/private/pip_compile_test.sh
+++ b/uv/private/pip_compile_test.sh
@@ -5,6 +5,7 @@ set -euo pipefail
 UV="{{uv}}"
 PYTHON_PLATFORM="{{python_platform}}"
 RESOLVED_PYTHON="{{resolved_python}}"
+PYTHON_VERSION="{{python_version}}"
 REQUIREMENTS_IN="{{requirements_in}}"
 REQUIREMENTS_TXT="{{requirements_txt}}"
 LABEL="{{label}}"
@@ -17,9 +18,6 @@ export PATH="$RESOLVED_PYTHON_BIN:$PATH"
 # make a writable copy of incoming requirements
 cp "$REQUIREMENTS_TXT" __updated__
 
-# get the version of python to hand to uv pip compile
-PYTHON_VERSION="$(python3 -c 'import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}")')"
-
 $UV pip compile \
     --quiet \
     --no-cache \
@@ -27,10 +25,10 @@ $UV pip compile \
     --emit-index-url \
     --no-strip-extras \
     --custom-compile-command "bazel run ${LABEL}" \
-    --python-version=$PYTHON_VERSION \
+    --python-version="$PYTHON_VERSION" \
     $(echo $PYTHON_PLATFORM) \
     -o __updated__ \
-    $REQUIREMENTS_IN
+    "$REQUIREMENTS_IN"
 
 # check files match
 DIFF="$(diff "$REQUIREMENTS_TXT" "__updated__" || true)"


### PR DESCRIPTION
Instead of running Python to emit its version, read the Python version from the toolchain in Starlark.
