### PR TITLE
feat(compile): add args attribute

### DIFF
--- a/uv/private/pip.bzl
+++ b/uv/private/pip.bzl
@@ -3,6 +3,9 @@
 _PY_TOOLCHAIN = "@bazel_tools//tools/python:toolchain_type"
 
 _common_attrs = {
+    "uv_args": attr.string_list(doc="""\
+A list of arguments to bake into the uv script. This means that the arguments
+will be used even if the user invokes uv via `bazel run //:uv_rule -- <extra_args>`"""),
     "requirements_in": attr.label(mandatory = True, allow_single_file = True),
     "requirements_txt": attr.label(mandatory = True, allow_single_file = True),
     "python_platform": attr.string(default = ""),
@@ -33,6 +36,7 @@ def _uv_pip_compile(ctx, template, executable, generator_label):
             "{{python_version}}": _python_version(py_toolchain),
             "{{python_platform}}": _python_platform(ctx.attr.python_platform),
             "{{label}}": str(generator_label),
+            "{{extra_arguments}}": " ".join(ctx.attr.uv_args)
         },
     )
 
@@ -80,7 +84,9 @@ _pip_compile_test = rule(
     test = True,
 )
 
-def pip_compile(name, requirements_in = None, requirements_txt = None, target_compatible_with = None, python_platform = None, tags = None):
+def pip_compile(
+        name, requirements_in = None, requirements_txt = None, target_compatible_with = None, python_platform = None, args = None, tags = None,
+):
     tags = tags or []
 
     _pip_compile(
@@ -89,6 +95,7 @@ def pip_compile(name, requirements_in = None, requirements_txt = None, target_co
         requirements_txt = requirements_txt or "//:requirements.txt",
         python_platform = python_platform or "",
         target_compatible_with = target_compatible_with,
+        uv_args = args,
     )
 
     _pip_compile_test(
@@ -99,4 +106,5 @@ def pip_compile(name, requirements_in = None, requirements_txt = None, target_co
         python_platform = python_platform or "",
         target_compatible_with = target_compatible_with,
         tags = ["requires-network"] + tags,
+        uv_args = args,
     )

--- a/uv/private/pip_compile.sh
+++ b/uv/private/pip_compile.sh
@@ -24,4 +24,4 @@ $UV pip compile \
     $(echo $PYTHON_PLATFORM) \
     -o "$REQUIREMENTS_TXT" \
     "$REQUIREMENTS_IN" \
-    "$@"
+    {{extra_arguments}} "$@"


### PR DESCRIPTION
This allows passing the index url and other parameters to uv via
a string list instead of using env variables. This means that the
we don't need to resort to `direnv` or `.bazelrc` to change the
indexes used by `uv`.
