### PR TITLE
Allow setting venv destination in rule

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ bazel-testlogs/
 bazel-*
 
 venv/
+.venv/

--- a/examples/typical/BUILD.bazel
+++ b/examples/typical/BUILD.bazel
@@ -10,3 +10,8 @@ pip_compile(
 )
 
 create_venv(name = "create-venv")
+
+create_venv(
+    name = "create-venv-custom-destination",
+    destination_folder = ".venv",
+)

--- a/uv/private/create_venv.sh
+++ b/uv/private/create_venv.sh
@@ -15,7 +15,7 @@ if [ $# -gt 1 ]; then
   echo "create-venv takes one optional argument, the path to the virtual environment."
   exit -1
 elif [ $# == 0 ] || [ -z "$1" ]; then
-  target="venv"
+  target="{{destination_folder}}"
 else
   target="$1"
 fi

--- a/uv/private/venv.bzl
+++ b/uv/private/venv.bzl
@@ -34,7 +34,7 @@ def _venv_impl(ctx):
 
 _venv = rule(
     attrs = {
-        "destination_folder": attr.string(mandatory = True, default = "venv"),
+        "destination_folder": attr.string(default = "venv"),
         "requirements_txt": attr.label(mandatory = True, allow_single_file = True),
         "_uv": attr.label(default = "@multitool//tools/uv", executable = True, cfg = "exec"),
         "_template": attr.label(default = "//uv/private:create_venv.sh", allow_single_file = True),

--- a/uv/private/venv.bzl
+++ b/uv/private/venv.bzl
@@ -34,7 +34,7 @@ def _venv_impl(ctx):
 
 _venv = rule(
     attrs = {
-        "destination_folder": attr.string(mandatory = True),
+        "destination_folder": attr.string(mandatory = True, default = "venv"),
         "requirements_txt": attr.label(mandatory = True, allow_single_file = True),
         "_uv": attr.label(default = "@multitool//tools/uv", executable = True, cfg = "exec"),
         "_template": attr.label(default = "//uv/private:create_venv.sh", allow_single_file = True),
@@ -44,7 +44,7 @@ _venv = rule(
     executable = True,
 )
 
-def create_venv(name, requirements_txt = None, target_compatible_with = None, destination_folder = "venv"):
+def create_venv(name, requirements_txt = None, target_compatible_with = None, destination_folder = None):
     _venv(
         name = name,
         destination_folder = destination_folder,

--- a/uv/private/venv.bzl
+++ b/uv/private/venv.bzl
@@ -11,6 +11,7 @@ def _uv_template(ctx, template, executable):
             "{{uv}}": ctx.executable._uv.short_path,
             "{{requirements_txt}}": ctx.file.requirements_txt.short_path,
             "{{resolved_python}}": py_toolchain.py3_runtime.interpreter.short_path,
+            "{{destination_folder}}": ctx.attr.destination_folder,
         },
     )
 
@@ -33,6 +34,7 @@ def _venv_impl(ctx):
 
 _venv = rule(
     attrs = {
+        "destination_folder": attr.string(mandatory = True),
         "requirements_txt": attr.label(mandatory = True, allow_single_file = True),
         "_uv": attr.label(default = "@multitool//tools/uv", executable = True, cfg = "exec"),
         "_template": attr.label(default = "//uv/private:create_venv.sh", allow_single_file = True),
@@ -42,9 +44,10 @@ _venv = rule(
     executable = True,
 )
 
-def create_venv(name, requirements_txt = None, target_compatible_with = None):
+def create_venv(name, requirements_txt = None, target_compatible_with = None, destination_folder = "venv"):
     _venv(
         name = name,
+        destination_folder = destination_folder,
         requirements_txt = requirements_txt or "//:requirements.txt",
         target_compatible_with = target_compatible_with,
     )


### PR DESCRIPTION
Previously we could pass the directory as an argument when executing the target.

Now it is also possible to set the default destination directory in code.