### PR TITLE
Use --python arg instead of PATH munging

### DIFF
--- a/uv/private/pip.bzl
+++ b/uv/private/pip.bzl
@@ -35,8 +35,8 @@ def _uv_pip_compile(
     args = []
     args += uv_args
     args.append("--custom-compile-command='{compile_command}'".format(compile_command = compile_command))
-    args.append("--python={python}".format(python = _python_version(py_toolchain)))
-    args.append("--python-version={version}".format(version = py_toolchain.py3_runtime.interpreter.short_path))
+    args.append("--python={python}".format(python = py_toolchain.py3_runtime.interpreter.short_path))
+    args.append("--python-version={version}".format(version = _python_version(py_toolchain)))
     if ctx.attr.python_platform:
         args.append("--python-platform={platform}".format(platform = ctx.attr.python_platform))
 

--- a/uv/private/pip.bzl
+++ b/uv/private/pip.bzl
@@ -35,7 +35,8 @@ def _uv_pip_compile(
     args = []
     args += uv_args
     args.append("--custom-compile-command='{compile_command}'".format(compile_command = compile_command))
-    args.append("--python-version={version}".format(version = _python_version(py_toolchain)))
+    args.append("--python={python}".format(python = _python_version(py_toolchain)))
+    args.append("--python-version={version}".format(version = py_toolchain.py3_runtime.interpreter.short_path))
     if ctx.attr.python_platform:
         args.append("--python-platform={platform}".format(platform = ctx.attr.python_platform))
 
@@ -48,7 +49,6 @@ def _uv_pip_compile(
             "{{requirements_in}}": ctx.file.requirements_in.short_path,
             "{{requirements_txt}}": ctx.file.requirements_txt.short_path,
             "{{compile_command}}": compile_command,
-            "{{resolved_python}}": py_toolchain.py3_runtime.interpreter.short_path,
         },
     )
 

--- a/uv/private/pip_compile.sh
+++ b/uv/private/pip_compile.sh
@@ -6,10 +6,6 @@ set -euo pipefail
 REQUIREMENTS_IN="{{requirements_in}}"
 REQUIREMENTS_TXT="{{requirements_txt}}"
 
-# set resolved python to front of the path
-RESOLVED_PYTHON_BIN="$(dirname "{{resolved_python}}")"
-export PATH="$RESOLVED_PYTHON_BIN:$PATH"
-
 {{uv}} pip compile \
     {{args}} \
     --output-file="$REQUIREMENTS_TXT" \

--- a/uv/private/pip_compile_test.sh
+++ b/uv/private/pip_compile_test.sh
@@ -7,10 +7,6 @@ REQUIREMENTS_IN="{{requirements_in}}"
 REQUIREMENTS_TXT="{{requirements_txt}}"
 COMPILE_COMMAND="{{compile_command}}"
 
-# set resolved python to front of the path
-RESOLVED_PYTHON_BIN="$(dirname "{{resolved_python}}")"
-export PATH="$RESOLVED_PYTHON_BIN:$PATH"
-
 # make a writable copy of incoming requirements
 cp "$REQUIREMENTS_TXT" __updated__
 


### PR DESCRIPTION
## Issue
We were updating PATH to get our desired Python interpreter at the front, but more recent versions of uv let us specify the interpreter explicitly.

## Summary
Specify the interpreter using `--python` instead of munging the path.
