### PR TITLE
refactor: rename diff_test target to match rules_python

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -34,7 +34,7 @@ Ensure both requirements.in and requirements.txt exist (the latter must exist bu
 
 Run the compilation step with `bazel run //:generate_requirements_txt`.
 
-This will automatically register a diff test with name `[name]_diff_test`.
+This will automatically register a diff test with name `[name]_test`.
 
 Additionally, you can specify the following optional args:
 

--- a/uv/private/pip.bzl
+++ b/uv/private/pip.bzl
@@ -138,7 +138,7 @@ def pip_compile(
 
     Targets produced by this macro are:
       [name]: a runnable target that will use requirements_in to generate and overwrite requirements_txt
-      [name]_diff_test: a testable target that will check that requirements_txt is up to date with requirements_in
+      [name]_test: a testable target that will check that requirements_txt is up to date with requirements_in
     """
     tags = tags or []
 
@@ -154,7 +154,7 @@ def pip_compile(
     )
 
     _pip_compile_test(
-        name = name + "_diff_test",
+        name = name + "_test",
         generator_label = name,
         requirements_in = requirements_in or "//:requirements.in",
         requirements_txt = requirements_txt or "//:requirements.txt",


### PR DESCRIPTION
Makes it easier for users to migrate from compile_pip_requirements.

See #96