### PR TITLE
fix: move pip_compile macro to public API file

### DIFF
--- a/uv/pip.bzl
+++ b/uv/pip.bzl
@@ -1,5 +1,71 @@
 "uv based pip compile rules"
 
-load("//uv/private:pip.bzl", _pip_compile = "pip_compile")
+load("//uv/private:pip.bzl", "pip_compile_test", _pip_compile = "pip_compile")
 
-pip_compile = _pip_compile
+def pip_compile(
+        name,
+        requirements_in = None,
+        requirements_txt = None,
+        target_compatible_with = None,
+        python_platform = None,
+        args = None,
+        data = None,
+        tags = None,
+        **kwargs):
+    """
+    Produce targets to compile a requirements.in or pyproject.toml file into a requirements.txt file.
+
+    Args:
+        name: name of the primary compilation target.
+        requirements_in: (optional, default "//:requirements.in") a label for the requirements.in file.
+        requirements_txt: (optional, default "//:requirements.txt") a label for the requirements.txt file.
+        python_platform: (optional) a uv pip compile compatible value for --python-platform.
+        target_compatible_with: (optional) specify that a particular target is compatible only with certain
+          Bazel platforms.
+        args: (optional) override the default arguments passed to uv pip compile, default arguments are:
+           --generate-hashes  (Include distribution hashes in the output file)
+           --emit-index-url   (Include `--index-url` and `--extra-index-url` entries in the generated output file)
+           --no-strip-extras  (Include extras in the output file)
+        data: (optional) a list of labels of additional files to include
+        tags: (optional) tags to apply to the generated test target
+        **kwargs: (optional) other fields passed through to all underlying rules
+
+    Targets produced by this macro are:
+      [name]: a runnable target that will use requirements_in to generate and overwrite requirements_txt
+      [name].update: an alias for [name]
+      [name]_test: a testable target that will check that requirements_txt is up to date with requirements_in
+    """
+    requirements_in = requirements_in or "//:requirements.in"
+    requirements_txt = requirements_txt or "//:requirements.txt"
+    tags = tags or []
+
+    _pip_compile(
+        name = name,
+        requirements_in = requirements_in,
+        requirements_txt = requirements_txt,
+        python_platform = python_platform,
+        target_compatible_with = target_compatible_with,
+        data = data,
+        uv_args = args,
+        **kwargs
+    )
+
+    # Also allow 'bazel run' with a "custom verb" https://bazel.build/rules/verbs-tutorial
+    # Provides compatibility with rules_python's compile_pip_requirements [name].update target.
+    native.alias(
+        name = name + ".update",
+        actual = name,
+    )
+
+    pip_compile_test(
+        name = name + "_test",
+        generator_label = name,
+        requirements_in = requirements_in,
+        requirements_txt = requirements_txt,
+        python_platform = python_platform or "",
+        target_compatible_with = target_compatible_with,
+        data = data,
+        uv_args = args,
+        tags = ["requires-network"] + tags,
+        **kwargs
+    )

--- a/uv/private/pip.bzl
+++ b/uv/private/pip.bzl
@@ -87,7 +87,7 @@ def _pip_compile_impl(ctx):
         runfiles = _runfiles(ctx),
     )
 
-_pip_compile = rule(
+pip_compile = rule(
     attrs = _COMMON_ATTRS | {
         "_template": attr.label(default = "//uv/private:pip_compile.sh", allow_single_file = True),
     },
@@ -117,7 +117,7 @@ def _pip_compile_test_impl(ctx):
         ),
     ]
 
-_pip_compile_test = rule(
+pip_compile_test = rule(
     attrs = _COMMON_ATTRS | {
         "generator_label": attr.label(mandatory = True),
         "_template": attr.label(default = "//uv/private:pip_compile_test.sh", allow_single_file = True),
@@ -126,69 +126,3 @@ _pip_compile_test = rule(
     implementation = _pip_compile_test_impl,
     test = True,
 )
-
-def pip_compile(
-        name,
-        requirements_in = None,
-        requirements_txt = None,
-        target_compatible_with = None,
-        python_platform = None,
-        args = None,
-        data = None,
-        tags = None,
-        **kwargs):
-    """
-    Produce targets to compile a requirements.in or pyproject.toml file into a requirements.txt file.
-
-    Args:
-        name: name of the primary compilation target.
-        requirements_in: (optional, default "//:requirements.in") a label for the requirements.in file.
-        requirements_txt: (optional, default "//:requirements.txt") a label for the requirements.txt file.
-        python_platform: (optional) a uv pip compile compatible value for --python-platform.
-        target_compatible_with: (optional) specify that a particular target is compatible only with certain
-          Bazel platforms.
-        args: (optional) override the default arguments passed to uv pip compile, default arguments are:
-           --generate-hashes  (Include distribution hashes in the output file)
-           --emit-index-url   (Include `--index-url` and `--extra-index-url` entries in the generated output file)
-           --no-strip-extras  (Include extras in the output file)
-        data: (optional) a list of labels of additional files to include
-        tags: (optional) tags to apply to the generated test target
-        **kwargs: (optional) other fields passed through to all underlying rules
-
-    Targets produced by this macro are:
-      [name]: a runnable target that will use requirements_in to generate and overwrite requirements_txt
-      [name].update: an alias for [name]
-      [name]_test: a testable target that will check that requirements_txt is up to date with requirements_in
-    """
-    tags = tags or []
-
-    _pip_compile(
-        name = name,
-        requirements_in = requirements_in or "//:requirements.in",
-        requirements_txt = requirements_txt or "//:requirements.txt",
-        python_platform = python_platform,
-        target_compatible_with = target_compatible_with,
-        data = data,
-        uv_args = args,
-        **kwargs
-    )
-
-    # Also allow 'bazel run' with a "custom verb" https://bazel.build/rules/verbs-tutorial
-    # Provides compatibility with rules_python's compile_pip_requirements [name].update target.
-    native.alias(
-        name = name + ".update",
-        actual = name,
-    )
-
-    _pip_compile_test(
-        name = name + "_test",
-        generator_label = name,
-        requirements_in = requirements_in or "//:requirements.in",
-        requirements_txt = requirements_txt or "//:requirements.txt",
-        python_platform = python_platform or "",
-        target_compatible_with = target_compatible_with,
-        data = data,
-        uv_args = args,
-        tags = ["requires-network"] + tags,
-        **kwargs
-    )


### PR DESCRIPTION
Allows the underlying rule to have a matching name with the macro.

Demo:

```
alexeagle@aspect-build bazel-examples % bazel print requirements:all
pip_compile(
    name = "runtime",
    requirements_in = "//:pyproject.toml",
    requirements_txt = "runtime.txt",
)

alexeagle@aspect-build bazel-examples % bazel query --output=label_kind requirements:all
pip_compile rule //requirements:runtime
alias rule //requirements:runtime.update
pip_compile_test rule //requirements:runtime_test
```

Fixes #113