### PR TITLE
Transition uv to the correct platform

### DIFF
--- a/uv/private/pip.bzl
+++ b/uv/private/pip.bzl
@@ -1,6 +1,7 @@
 "uv based pip compile rules"
 
 load("@rules_python//python:defs.bzl", "PyRuntimeInfo")
+load(":transition_to_target.bzl", "transition_to_target")
 
 _PY_TOOLCHAIN = "@bazel_tools//tools/python:toolchain_type"
 
@@ -17,7 +18,7 @@ _COMMON_ATTRS = {
     "py3_runtime": attr.label(),
     "data": attr.label_list(allow_files = True),
     "uv_args": attr.string_list(default = _DEFAULT_ARGS),
-    "_uv": attr.label(default = "@multitool//tools/uv", executable = True, cfg = "exec"),
+    "_uv": attr.label(default = "@multitool//tools/uv", executable = True, cfg = transition_to_target),
 }
 
 def _python_version(py3_runtime):
@@ -70,7 +71,7 @@ def _runfiles(ctx):
         files = [ctx.file.requirements_in, ctx.file.requirements_txt] + ctx.files.data,
         transitive_files = py3_runtime.files,
     )
-    runfiles = runfiles.merge(ctx.attr._uv.default_runfiles)
+    runfiles = runfiles.merge(ctx.attr._uv[0].default_runfiles)
     return runfiles
 
 def _pip_compile_impl(ctx):

--- a/uv/private/transition_to_target.bzl
+++ b/uv/private/transition_to_target.bzl
@@ -1,4 +1,5 @@
-# Helper rule to ensure that uv is resolved for the target architecture
+"Helper rule to ensure that uv is resolved for the target architecture"
+
 def _transition_to_target_impl(settings, _attr):
     return {
         # String conversion is needed to prevent a crash with Bazel 6.x.

--- a/uv/private/transition_to_target.bzl
+++ b/uv/private/transition_to_target.bzl
@@ -1,0 +1,16 @@
+# Helper rule to ensure that uv is resolved for the target architecture
+def _transition_to_target_impl(settings, _attr):
+    return {
+        # String conversion is needed to prevent a crash with Bazel 6.x.
+        "//command_line_option:extra_execution_platforms": [
+            str(platform)
+            for platform in settings["//command_line_option:platforms"]
+        ],
+    }
+
+transition_to_target = transition(
+    implementation = _transition_to_target_impl,
+    inputs = ["//command_line_option:platforms"],
+    outputs = ["//command_line_option:extra_execution_platforms"],
+)
+

--- a/uv/private/transition_to_target.bzl
+++ b/uv/private/transition_to_target.bzl
@@ -14,4 +14,3 @@ transition_to_target = transition(
     inputs = ["//command_line_option:platforms"],
     outputs = ["//command_line_option:extra_execution_platforms"],
 )
-

--- a/uv/private/venv.bzl
+++ b/uv/private/venv.bzl
@@ -1,5 +1,7 @@
 "uv based venv generation"
 
+load(":transition_to_target.bzl", "transition_to_target")
+
 _PY_TOOLCHAIN = "@bazel_tools//tools/python:toolchain_type"
 
 def _uv_template(ctx, template, executable):
@@ -23,7 +25,7 @@ def _runfiles(ctx):
         files = [ctx.file.requirements_txt] + ctx.files.site_packages_extra_files,
         transitive_files = py_toolchain.py3_runtime.files,
     )
-    runfiles = runfiles.merge(ctx.attr._uv.default_runfiles)
+    runfiles = runfiles.merge(ctx.attr._uv[0].default_runfiles)
     return runfiles
 
 def _venv_impl(ctx):
@@ -39,7 +41,7 @@ _venv = rule(
         "destination_folder": attr.string(default = "venv"),
         "site_packages_extra_files": attr.label_list(default = [], doc = "Files to add to the site-packages folder inside the virtual environment. Useful for adding `sitecustomize.py` or `.pth` files", allow_files = True),
         "requirements_txt": attr.label(mandatory = True, allow_single_file = True),
-        "_uv": attr.label(default = "@multitool//tools/uv", executable = True, cfg = "exec"),
+        "_uv": attr.label(default = "@multitool//tools/uv", executable = True, cfg = transition_to_target),
         "_template": attr.label(default = "//uv/private:create_venv.sh", allow_single_file = True),
     },
     toolchains = [_PY_TOOLCHAIN],


### PR DESCRIPTION
Currently, uv is selected for the exec platform. If it were used as part of a build action, this would be correct, but as it is invoked by an emitted shell script it is not. This causes it to fail when running builds on one platform, but targeting another. This is the case, for example, when running builds in a remote execution cluster with Linux workers, but compiling for a Mac. This patch transitions uv to the proper platform, allowing it to work in this situation.