### PR TITLE
Use uv pip sync and allow-existing instead of uv pip install

### DIFF
--- a/uv/private/create_venv.sh
+++ b/uv/private/create_venv.sh
@@ -26,9 +26,9 @@ then
   exit -1
 fi
 
-"$UV" venv "$BUILD_WORKSPACE_DIRECTORY/$target" --python "$PYTHON"
+"$UV" venv "$BUILD_WORKSPACE_DIRECTORY/$target" --python "$PYTHON"  --allow-existing
 source "$BUILD_WORKSPACE_DIRECTORY/$target/bin/activate"
-"$UV" pip install -r "$REQUIREMENTS_TXT" {{args}}
+"$UV" pip sync "$REQUIREMENTS_TXT" {{args}}
 
 site_packages_extra_files=({{site_packages_extra_files}})
 if [ ! -z ${site_packages_extra_files+x} ]; then


### PR DESCRIPTION
Prior to this change, `uv venv` wipes out the virtual env target, resulting in longer installations when using private pypi indexes that don't support caching. Adding the `allow-existing` maintains the virtualenv if it exists, and using `uv pip sync`  ensures the virtualenv doesn't retain unused dependencies. 