### PR TITLE
Enable create_venv for non-interactive runs

### DIFF
--- a/uv/private/create_venv.sh
+++ b/uv/private/create_venv.sh
@@ -8,6 +8,10 @@ REQUIREMENTS_TXT="{{requirements_txt}}"
 
 PYTHON="$(realpath "$RESOLVED_PYTHON")"
 
+if [ -z ${TERM} ] || [ ${TERM} == "dumb" ]; then
+   export TERM=xterm
+fi
+
 bold="$(tput bold)"
 normal="$(tput sgr0)"
 


### PR DESCRIPTION
When using `create_venv` in non-interactive docker container runs, we would get:
```
tput: No value for $TERM and no -T specified
```
This sets `TERM` in case it isn't and enables such runs.