### PR TITLE
Add sync_venv macro

### DIFF
--- a/examples/typical/BUILD.bazel
+++ b/examples/typical/BUILD.bazel
@@ -1,5 +1,5 @@
 load("@rules_uv//uv:pip.bzl", "pip_compile")
-load("@rules_uv//uv:venv.bzl", "create_venv")
+load("@rules_uv//uv:venv.bzl", "create_venv", "sync_venv")
 
 pip_compile(name = "generate_requirements_txt")
 
@@ -24,4 +24,9 @@ create_venv(
     site_packages_extra_files = [
         "site_packages_extra/sitecustomize.py",
     ],
+)
+
+sync_venv(
+    name = "sync-venv",
+    destination_folder = ".sync-venv",
 )

--- a/uv/private/BUILD.bazel
+++ b/uv/private/BUILD.bazel
@@ -4,6 +4,7 @@ exports_files([
     "create_venv.sh",
     "pip_compile_test.sh",
     "pip_compile.sh",
+    "sync_venv.sh",
 ])
 
 bzl_library(

--- a/uv/private/sync_venv.sh
+++ b/uv/private/sync_venv.sh
@@ -26,9 +26,9 @@ then
   exit -1
 fi
 
-"$UV" venv "$BUILD_WORKSPACE_DIRECTORY/$target" --python "$PYTHON"
+"$UV" venv "$BUILD_WORKSPACE_DIRECTORY/$target" --python "$PYTHON"  --allow-existing
 source "$BUILD_WORKSPACE_DIRECTORY/$target/bin/activate"
-"$UV" pip install -r "$REQUIREMENTS_TXT" {{args}}
+"$UV" pip sync "$REQUIREMENTS_TXT" {{args}}
 
 site_packages_extra_files=({{site_packages_extra_files}})
 if [ ! -z ${site_packages_extra_files+x} ]; then

--- a/uv/private/venv.bzl
+++ b/uv/private/venv.bzl
@@ -31,7 +31,7 @@ def _runfiles(ctx):
 
 def _venv_impl(ctx):
     executable = ctx.actions.declare_file(ctx.attr.name)
-    _uv_template(ctx, ctx.file._template, executable)
+    _uv_template(ctx, ctx.file.template, executable)
     return DefaultInfo(
         executable = executable,
         runfiles = _runfiles(ctx),
@@ -43,7 +43,7 @@ _venv = rule(
         "site_packages_extra_files": attr.label_list(default = [], doc = "Files to add to the site-packages folder inside the virtual environment. Useful for adding `sitecustomize.py` or `.pth` files", allow_files = True),
         "requirements_txt": attr.label(mandatory = True, allow_single_file = True),
         "_uv": attr.label(default = "@multitool//tools/uv", executable = True, cfg = transition_to_target),
-        "_template": attr.label(default = "//uv/private:create_venv.sh", allow_single_file = True),
+        "template": attr.label(allow_single_file = True),
         "uv_args": attr.string_list(default = []),
     },
     toolchains = [_PY_TOOLCHAIN],
@@ -59,4 +59,16 @@ def create_venv(name, requirements_txt = None, target_compatible_with = None, de
         requirements_txt = requirements_txt or "//:requirements.txt",
         target_compatible_with = target_compatible_with,
         uv_args = uv_args,
+        template = "@rules_uv//uv/private:create_venv.sh",
+    )
+
+def sync_venv(name, requirements_txt = None, target_compatible_with = None, destination_folder = None, site_packages_extra_files = [], uv_args = []):
+    _venv(
+        name = name,
+        destination_folder = destination_folder,
+        site_packages_extra_files = site_packages_extra_files,
+        requirements_txt = requirements_txt or "//:requirements.txt",
+        target_compatible_with = target_compatible_with,
+        uv_args = uv_args,
+        template = "@rules_uv//uv/private:sync_venv.sh",
     )

--- a/uv/venv.bzl
+++ b/uv/venv.bzl
@@ -1,5 +1,6 @@
 "uv based virtual env generation"
 
-load("//uv/private:venv.bzl", _create_venv = "create_venv")
+load("//uv/private:venv.bzl", _create_venv = "create_venv", _sync_venv = "sync_venv")
 
 create_venv = _create_venv
+sync_venv = _sync_venv


### PR DESCRIPTION
In #166, create_venv was switched to perform a `uv pip sync`, but this has slightly different semantics than `uv pip install`. The latter will expand the input requirements as needed, while the former treats the input as a complete lockfile. To achieve both behaviors, revert `create_venv` to its old functionality and add a `sync_venv` macro that runs `uv pip sync`.