### PR TITLE
Add extra_args atttribute to append to default args

### DIFF
--- a/uv/pip.bzl
+++ b/uv/pip.bzl
@@ -12,6 +12,7 @@ def pip_compile(
         python_platform = None,
         universal = False,
         args = None,
+        extra_args = None,
         data = None,
         tags = None,
         size = None,
@@ -32,6 +33,8 @@ def pip_compile(
            --generate-hashes  (Include distribution hashes in the output file)
            --emit-index-url   (Include `--index-url` and `--extra-index-url` entries in the generated output file)
            --no-strip-extras  (Include extras in the output file)
+        extra_args: (optional) appends to the default arguments passed to uv pip compile. If both args and
+            extra_args are provided, extra_args will be appended to args.
         data: (optional) a list of labels of additional files to include
         tags: (optional) tags to apply to the generated test target
         size: (optional) size of the test target, see https://bazel.build/reference/test-encyclopedia#role-test-runner
@@ -64,6 +67,7 @@ def pip_compile(
         target_compatible_with = target_compatible_with,
         data = data,
         uv_args = args,
+        extra_args = extra_args,
         **kwargs
     )
 
@@ -84,6 +88,7 @@ def pip_compile(
         target_compatible_with = target_compatible_with,
         data = data,
         uv_args = args,
+        extra_args = extra_args,
         tags = ["requires-network"] + tags,
         size = size,
         **kwargs

--- a/uv/private/pip.bzl
+++ b/uv/private/pip.bzl
@@ -19,6 +19,7 @@ _COMMON_ATTRS = {
     "py3_runtime": attr.label(),
     "data": attr.label_list(allow_files = True),
     "uv_args": attr.string_list(default = _DEFAULT_ARGS),
+    "extra_args": attr.string_list(),
     "_uv": attr.label(default = "@multitool//tools/uv", executable = True, cfg = transition_to_target),
 }
 
@@ -42,12 +43,14 @@ def _uv_pip_compile(
         template,
         executable,
         generator_label,
-        uv_args):
+        uv_args,
+        extra_args):
     py3_runtime = _python_runtime(ctx)
     compile_command = "bazel run {label}".format(label = str(generator_label))
 
     args = []
     args += uv_args
+    args += extra_args
     args.append("--custom-compile-command='{compile_command}'".format(compile_command = compile_command))
     args.append("--python={python}".format(python = py3_runtime.interpreter.short_path))
     args.append("--python-version={version}".format(version = _python_version(py3_runtime)))
@@ -85,6 +88,7 @@ def _pip_compile_impl(ctx):
         executable = executable,
         generator_label = ctx.label,
         uv_args = ctx.attr.uv_args,
+        extra_args = ctx.attr.extra_args,
     )
     return DefaultInfo(
         executable = executable,
@@ -108,6 +112,7 @@ def _pip_compile_test_impl(ctx):
         executable = executable,
         generator_label = ctx.attr.generator_label.label,
         uv_args = ctx.attr.uv_args,
+        extra_args = ctx.attr.extra_args,
     )
     return [
         DefaultInfo(


### PR DESCRIPTION
Closes https://github.com/theoremlp/rules_uv/issues/199

This allows for specifying `extra_args`  which are appended to the default args or overwritten `args`. This way, you can for instance select an extra such as `extra_args = ["--extra=dev-dependencies"]` without having to copy/past the default args.