### PR TITLE
Make buildifier a dev dependency

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -7,10 +7,11 @@ module(
 )
 
 bazel_dep(name = "bazel_skylib", version = "1.4.1")
-bazel_dep(name = "buildifier_prebuilt", version = "7.3.1")
 bazel_dep(name = "platforms", version = "0.0.8")
 bazel_dep(name = "rules_multitool", version = "0.11.0")
 bazel_dep(name = "rules_python", version = "0.34.0")
+
+bazel_dep(name = "buildifier_prebuilt", version = "7.3.1", dev_dependency = True)
 
 multitool = use_extension("@rules_multitool//multitool:extension.bzl", "multitool")
 multitool.hub(lockfile = "//uv/private:uv.lock.json")


### PR DESCRIPTION
This seems to be a clear dev dependency that should not be exposed to the user