### PR TITLE
Make venv removeable

### DIFF
--- a/uv/private/create_venv.sh
+++ b/uv/private/create_venv.sh
@@ -43,6 +43,7 @@ if [ ! -z ${site_packages_extra_files+x} ]; then
   site_packages_dir=$(find "$target/lib" -type d -name 'site-packages')
   for file in "${site_packages_extra_files[@]}"; do
     cp "$file" "$site_packages_dir"/
+    chmod +w "$site_packages_dir"/"$file"
   done
 fi
 

--- a/uv/private/sync_venv.sh
+++ b/uv/private/sync_venv.sh
@@ -35,6 +35,7 @@ if [ ! -z ${site_packages_extra_files+x} ]; then
   site_packages_dir=$(find "$BUILD_WORKSPACE_DIRECTORY/$target/lib" -type d -name 'site-packages')
   for file in "${site_packages_extra_files[@]}"; do
     cp "$file" "$site_packages_dir"/
+    chmod +w "$site_packages_dir"/"$file"
   done
 fi
 


### PR DESCRIPTION
* bazel creates file write-protected
* using site_packages_extra_files will then cause issues when removing the created venv:
```
rm .venv/lib/python3.12/site-packages/sitecustomize.py
rm: remove write-protected regular file '.venv/lib/python3.12/site-packages/sitecustomize.py'?
```
* this is especially an issue in combination with sync_venv
