### PR TITLE
Make buildifier_prebuilt a dev dependency

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -5,6 +5,9 @@ docs/*.md linguist-generated=true
 # Configuration for 'git archive'
 # See https://git-scm.com/docs/git-archive#ATTRIBUTES
 
+# Don't include dev-only targets in the distribution artifact.
+dev export-ignore
+
 # Don't include examples in the distribution artifact, to reduce size.
 # You may want to add additional exclusions for folders or files that users don't need.
 examples export-ignore

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,22 +1,3 @@
-load("@buildifier_prebuilt//:rules.bzl", "buildifier", "buildifier_test")
-
 exports_files([
     "MODULE.bazel",
 ])
-
-buildifier(
-    name = "buildifier.fix",
-    exclude_patterns = ["./.git/*"],
-    lint_mode = "fix",
-    mode = "fix",
-    visibility = ["//thm/buildtools/fix:__pkg__"],
-)
-
-buildifier_test(
-    name = "buildifier.test",
-    exclude_patterns = ["./.git/*"],
-    lint_mode = "warn",
-    mode = "diff",
-    no_sandbox = True,
-    workspace = "//:MODULE.bazel",
-)

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -7,10 +7,11 @@ module(
 )
 
 bazel_dep(name = "bazel_skylib", version = "1.4.1")
-bazel_dep(name = "buildifier_prebuilt", version = "7.3.1")
 bazel_dep(name = "platforms", version = "0.0.8")
 bazel_dep(name = "rules_multitool", version = "0.11.0")
 bazel_dep(name = "rules_python", version = "0.34.0")
+
+bazel_dep(name = "buildifier_prebuilt", version = "7.3.1", dev_dependency = True)
 
 multitool = use_extension("@rules_multitool//multitool:extension.bzl", "multitool")
 multitool.hub(lockfile = "//uv/private:uv.lock.json")

--- a/dev/BUILD.bazel
+++ b/dev/BUILD.bazel
@@ -1,0 +1,17 @@
+load("@buildifier_prebuilt//:rules.bzl", "buildifier", "buildifier_test")
+
+buildifier(
+    name = "buildifier.fix",
+    exclude_patterns = ["./.git/*"],
+    lint_mode = "fix",
+    mode = "fix",
+)
+
+buildifier_test(
+    name = "buildifier.test",
+    exclude_patterns = ["./.git/*"],
+    lint_mode = "warn",
+    mode = "diff",
+    no_sandbox = True,
+    workspace = "//:MODULE.bazel",
+)


### PR DESCRIPTION
Move buildifier_prebuilt targets into a dev folder and exclude the dev folder from the built artifact. Then, update buildifier_prebuilt to be a dev_dependency.
