### PR TITLE
Add `uv export` in bazel

### DIFF
--- a/uv/BUILD.bazel
+++ b/uv/BUILD.bazel
@@ -7,6 +7,12 @@ bzl_library(
 )
 
 bzl_library(
+    name = "uv_export",
+    srcs = ["uv_export.bzl"],
+    visibility = ["//visibility:public"],
+)
+
+bzl_library(
     name = "venv",
     srcs = ["venv.bzl"],
     visibility = ["//visibility:public"],

--- a/uv/private/BUILD.bazel
+++ b/uv/private/BUILD.bazel
@@ -5,6 +5,8 @@ exports_files([
     "pip_compile_test.sh",
     "pip_compile.sh",
     "sync_venv.sh",
+    "uv_export.sh",
+    "uv_export_test.sh"
 ])
 
 bzl_library(

--- a/uv/private/uv_export.bzl
+++ b/uv/private/uv_export.bzl
@@ -1,0 +1,128 @@
+"uv based export rules"
+
+load("@rules_python//python:defs.bzl", "PyRuntimeInfo")
+load(":transition_to_target.bzl", "transition_to_target")
+
+_PY_TOOLCHAIN = "@bazel_tools//tools/python:toolchain_type"
+
+_DEFAULT_ARGS = [
+    "--all-extras",
+    "--no-emit-workspace",
+    "--no-sources"
+]
+
+_COMMON_ATTRS = {
+    "pyproject_toml": attr.label(mandatory = True, allow_single_file = True),
+    "requirements_txt": attr.label(mandatory = True, allow_single_file = True),
+    "python_platform": attr.string(),
+    "py3_runtime": attr.label(),
+    "data": attr.label_list(allow_files = True),
+    "uv_args": attr.string_list(default = _DEFAULT_ARGS),
+    "extra_args": attr.string_list(),
+    "env": attr.string_dict(),
+    "_uv": attr.label(default = "@multitool//tools/uv", executable = True, cfg = transition_to_target),
+}
+
+def _python_runtime(ctx):
+    if ctx.attr.py3_runtime:
+        return ctx.attr.py3_runtime[PyRuntimeInfo]
+    py_toolchain = ctx.toolchains[_PY_TOOLCHAIN]
+    return py_toolchain.py3_runtime
+
+def _uv_export(
+        ctx,
+        template,
+        executable,
+        generator_label,
+        uv_args,
+        extra_args):
+    py3_runtime = _python_runtime(ctx)
+    compile_command = "bazel run {label}".format(label = str(generator_label))
+
+    args = []
+    args += uv_args
+    args += extra_args
+    args.append("--python={python}".format(python = py3_runtime.interpreter.short_path))
+
+    ctx.actions.expand_template(
+        template = template,
+        output = executable,
+        substitutions = {
+            "{{uv}}": ctx.executable._uv.short_path,
+            "{{args}}": " \\\n    ".join(args),
+            "{{requirements_txt}}": ctx.file.requirements_txt.short_path,
+            "{{compile_command}}": compile_command,
+        },
+    )
+
+def _runfiles(ctx):
+    py3_runtime = _python_runtime(ctx)
+    runfiles = ctx.runfiles(
+        files = [ctx.file.pyproject_toml, ctx.file.requirements_txt] + ctx.files.data,
+        transitive_files = py3_runtime.files,
+    )
+    runfiles = runfiles.merge(ctx.attr._uv[0].default_runfiles)
+    return runfiles
+
+def _uv_export_impl(ctx):
+    executable = ctx.actions.declare_file(ctx.attr.name)
+    _uv_export(
+        ctx = ctx,
+        template = ctx.file._template,
+        executable = executable,
+        generator_label = ctx.label,
+        uv_args = ctx.attr.uv_args,
+        extra_args = ctx.attr.extra_args,
+    )
+    return [
+        DefaultInfo(
+            executable = executable,
+            runfiles = _runfiles(ctx),
+        ),
+        RunEnvironmentInfo(
+            environment = ctx.attr.env,
+        ),
+    ]
+
+uv_export = rule(
+    attrs = _COMMON_ATTRS | {
+        "_template": attr.label(default = "//uv/private:uv_export.sh", allow_single_file = True),
+    },
+    toolchains = [_PY_TOOLCHAIN],
+    implementation = _uv_export_impl,
+    executable = True,
+)
+
+def _uv_export_test_impl(ctx):
+    executable = ctx.actions.declare_file(ctx.attr.name)
+    _uv_export(
+        ctx = ctx,
+        template = ctx.file._template,
+        executable = executable,
+        generator_label = ctx.attr.generator_label.label,
+        uv_args = ctx.attr.uv_args,
+        extra_args = ctx.attr.extra_args,
+    )
+
+    return [
+        DefaultInfo(
+            executable = executable,
+            runfiles = _runfiles(ctx),
+        ),
+        RunEnvironmentInfo(
+            environment = ctx.attr.env,
+            # Ensures that .netrc can be detected by uv
+            # See https://github.com/theoremlp/rules_uv/issues/103
+            inherited_environment = ["HOME"],
+        ),
+    ]
+
+uv_export_test = rule(
+    attrs = _COMMON_ATTRS | {
+        "generator_label": attr.label(mandatory = True),
+        "_template": attr.label(default = "//uv/private:uv_export_test.sh", allow_single_file = True),
+    },
+    toolchains = [_PY_TOOLCHAIN],
+    implementation = _uv_export_test_impl,
+    test = True,
+)

--- a/uv/private/uv_export.sh
+++ b/uv/private/uv_export.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# inputs from Bazel
+PYPROJECT_TOML="{{pyproject_toml}}"
+REQUIREMENTS_TXT="{{requirements_txt}}"
+
+{{uv}} export \
+    {{args}} \
+    --output-file="$REQUIREMENTS_TXT" \
+    "$@"

--- a/uv/private/uv_export_test.sh
+++ b/uv/private/uv_export_test.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# inputs from Bazel
+PYPROJECT_TOML="{{pyproject_toml}}"
+REQUIREMENTS_TXT="{{requirements_txt}}"
+COMPILE_COMMAND="{{compile_command}}"
+
+# make a writable copy of incoming requirements
+updated_file=$(mktemp)
+trap 'rm -f "$updated_file"' EXIT
+cp "$REQUIREMENTS_TXT" "$updated_file"
+
+{{uv}} export \
+    --quiet \
+    --no-cache \
+    {{args}} \
+    --output-file="$updated_file"
+
+# check files match
+DIFF="$(diff -I '^#[[:space:]]*uv export' "$REQUIREMENTS_TXT" "$updated_file" || true)"
+if [ "$DIFF" != "" ]
+then
+  echo >&2 "FAIL: $REQUIREMENTS_TXT is out-of-date. Run '$COMPILE_COMMAND' to update."
+  echo >&2 "$DIFF"
+  exit 1
+fi

--- a/uv/uv_export.bzl
+++ b/uv/uv_export.bzl
@@ -1,0 +1,80 @@
+"uv based export rules"
+
+load("//uv/private:uv_export.bzl", "uv_export_test", _uv_export = "uv_export")
+
+def uv_export(
+        name,
+        pyproject_toml = None,
+        requirements_txt = None,
+        target_compatible_with = None,
+        args = None,
+        extra_args = None,
+        data = None,
+        tags = None,
+        size = None,
+        env = None,
+        **kwargs):
+    """
+    Produce targets to compile a pyproject.toml file into a requirements.txt file.
+
+    Args:
+        name: name of the primary compilation target.
+        pyproject_toml: (optional, default "//:pyproject.toml") a label for the requirements.in file.
+        requirements_txt: (optional, default "//:requirements.txt") a label for the requirements.txt file.
+        python: (optional) a uv export compatible value for --python.
+        target_compatible_with: (optional) specify that a particular target is compatible only with certain
+          Bazel platforms.
+        args: (optional) override the default arguments passed to uv export, default arguments are:
+           --all-extras  (Include all optional dependencies)
+           --no-emit-workspace (Do not emit any workspace members, including the root project)
+        extra_args: (optional) appends to the default arguments passed to uv export. If both args and
+            extra_args are provided, extra_args will be appended to args.
+        data: (optional) a list of labels of additional files to include
+        tags: (optional) tags to apply to the generated test target
+        size: (optional) size of the test target, see https://bazel.build/reference/test-encyclopedia#role-test-runner
+        env: (optional) a dictionary of environment variables to set for uv export and the test target
+        **kwargs: (optional) other fields passed through to all underlying rules
+
+    Targets produced by this macro are:
+      [name]: a runnable target that will use pyproject_toml to generate and overwrite requirements_txt
+      [name].update: an alias for [name]
+      [name]_test: a testable target that will check that requirements_txt is up to date with pyproject_toml
+    """
+    pyproject_toml = pyproject_toml or "//:pyproject.toml"
+    requirements_txt = requirements_txt or "//:requirements.txt"
+    tags = tags or []
+    size = size or "small"
+
+    _uv_export(
+        name = name,
+        pyproject_toml = pyproject_toml,
+        requirements_txt = requirements_txt,
+        target_compatible_with = target_compatible_with,
+        data = data,
+        uv_args = args,
+        extra_args = extra_args,
+        env = env,
+        **kwargs
+    )
+
+    # Also allow 'bazel run' with a "custom verb" https://bazel.build/rules/verbs-tutorial
+    # Provides compatibility with rules_python's compile_pip_requirements [name].update target.
+    native.alias(
+        name = name + ".update",
+        actual = name,
+    )
+
+    uv_export_test(
+        name = name + "_test",
+        generator_label = name,
+        pyproject_toml = pyproject_toml,
+        requirements_txt = requirements_txt,
+        target_compatible_with = target_compatible_with,
+        data = data,
+        uv_args = args,
+        extra_args = extra_args,
+        tags = ["requires-network"] + tags,
+        size = size,
+        env = env,
+        **kwargs
+    )


### PR DESCRIPTION
This adds the `uv export` command to bazel. `uv export` and `uv pip compile` have some slightly different behaviors. The main difference comes when using a [uv workspace](https://docs.astral.sh/uv/concepts/projects/workspaces/). With `uv export` you can ignore those packages, which is probably the behavior you want in a monorepo with bazel. The code is very similar to the one from `pip compile`.

If you are supportive of this change, I will add docs and update the README.

Thanks!