### PR TITLE
Add support for python toolchains accessible via interpreter_path

### DIFF
--- a/uv/private/interpreter_path.bzl
+++ b/uv/private/interpreter_path.bzl
@@ -1,0 +1,6 @@
+"Helper to handle local vs hermetic Python toolchains"
+
+def python_interpreter_path(py3_runtime):
+    if py3_runtime.interpreter:
+        return py3_runtime.interpreter.short_path
+    return py3_runtime.interpreter_path

--- a/uv/private/pip.bzl
+++ b/uv/private/pip.bzl
@@ -1,6 +1,7 @@
 "uv based pip compile rules"
 
 load("@rules_python//python:defs.bzl", "PyRuntimeInfo")
+load(":interpreter_path.bzl", "python_interpreter_path")
 load(":transition_to_target.bzl", "transition_to_target")
 
 _PY_TOOLCHAIN = "@bazel_tools//tools/python:toolchain_type"
@@ -54,7 +55,7 @@ def _uv_pip_compile(
     args += uv_args
     args += extra_args
     args.append("--custom-compile-command='{compile_command}'".format(compile_command = compile_command))
-    args.append("--python={python}".format(python = py3_runtime.interpreter.short_path))
+    args.append("--python={python}".format(python = python_interpreter_path(py3_runtime)))
     args.append("--python-version={version}".format(version = _python_version(py3_runtime)))
     if ctx.attr.python_platform:
         args.append("--python-platform={platform}".format(platform = ctx.attr.python_platform))

--- a/uv/private/venv.bzl
+++ b/uv/private/venv.bzl
@@ -1,5 +1,6 @@
 "uv based venv generation"
 
+load(":interpreter_path.bzl", "python_interpreter_path")
 load(":transition_to_target.bzl", "transition_to_target")
 
 _PY_TOOLCHAIN = "@bazel_tools//tools/python:toolchain_type"
@@ -13,7 +14,7 @@ def _uv_template(ctx, template, executable):
         substitutions = {
             "{{uv}}": ctx.executable._uv.short_path,
             "{{requirements_txt}}": ctx.file.requirements_txt.short_path,
-            "{{resolved_python}}": py_toolchain.py3_runtime.interpreter.short_path,
+            "{{resolved_python}}": python_interpreter_path(py_toolchain.py3_runtime),
             "{{destination_folder}}": ctx.attr.destination_folder,
             "{{site_packages_extra_files}}": " ".join(["'" + file.short_path + "'" for file in ctx.files.site_packages_extra_files]),
             "{{args}}": " \\\n    ".join(ctx.attr.uv_args),


### PR DESCRIPTION
When using a local python toolchain as defined [here](https://github.com/bazel-contrib/rules_python/blob/main/docs/toolchains.md#local-toolchain), the `py3_runtime.interpreter` will be set to `None` with the interpreter path accessible via `py3_runtime.interpreter_path`

[Here's](https://github.com/bazel-contrib/rules_python/blob/af9e959538f34878ca0ccccd97d51dc7b3ffdadd/python/private/py_executable.bzl#L1019) an example of code that handles this in rules_python