### PR TITLE
bug: Do not require projects that use rules_uv as transitive dependency to always have `bazel_dep(rules_uv)`

### DIFF
--- a/uv/private/venv.bzl
+++ b/uv/private/venv.bzl
@@ -60,7 +60,7 @@ def create_venv(name, requirements_txt = None, target_compatible_with = None, de
         requirements_txt = requirements_txt or "//:requirements.txt",
         target_compatible_with = target_compatible_with,
         uv_args = uv_args,
-        template = "//uv/private:create_venv.sh",
+        template = Label("//uv/private:create_venv.sh"),
     )
 
 def sync_venv(name, requirements_txt = None, target_compatible_with = None, destination_folder = None, site_packages_extra_files = [], uv_args = []):
@@ -71,5 +71,5 @@ def sync_venv(name, requirements_txt = None, target_compatible_with = None, dest
         requirements_txt = requirements_txt or "//:requirements.txt",
         target_compatible_with = target_compatible_with,
         uv_args = uv_args,
-        template = "//uv/private:sync_venv.sh",
+        template = Label("//uv/private:sync_venv.sh"),
     )


### PR DESCRIPTION
# Describe the issue

https://github.com/bazel-contrib/rules_uv/issues/303

# Solution

Because `rules_uv` directly reference `@rules_uv`. sing `Label(...)` addresses this.

Relative reference does not work since this is a macro, and it will resolve in the caller project.