### PR TITLE
pip_compile: Add extra_srcs attribute

### DIFF
--- a/examples/multiple-inputs/BUILD.bazel
+++ b/examples/multiple-inputs/BUILD.bazel
@@ -4,6 +4,7 @@ load("@rules_uv//uv:venv.bzl", "create_venv")
 pip_compile(
     name = "generate_requirements_txt",
     data = ["//:requirements.test.in"],
+    extra_srcs = ["//:pyproject.toml"],
 )
 
 create_venv(name = "create-venv")

--- a/examples/multiple-inputs/pyproject.toml
+++ b/examples/multiple-inputs/pyproject.toml
@@ -1,0 +1,4 @@
+[project]
+name = "multiple-inputs-example"
+version = "0.1.0"
+dependencies = ["colorama~=0.4.6"]

--- a/examples/multiple-inputs/requirements.txt
+++ b/examples/multiple-inputs/requirements.txt
@@ -2,21 +2,25 @@
 #    bazel run @@//:generate_requirements_txt
 --index-url https://pypi.org/simple
 
-click==8.1.7 \
-    --hash=sha256:ae74fb96c20a0277a1d615f1e4d73c8414f5a98db8b799a7931d1582f3390c28 \
-    --hash=sha256:ca9853ad459e787e2192211578cc907e7594e294c7ccc834310722b41b9ca6de
+click==8.1.8 \
+    --hash=sha256:63c132bbbed01578a06712a2d1f497bb62d9c1c0d329b7903a866228027263b2 \
+    --hash=sha256:ed53c9d8990d83c2a27deae68e4ee337473f6330c040a31d4225c9574d16096a
     # via -r requirements.in
-iniconfig==2.0.0 \
-    --hash=sha256:2d91e135bf72d31a410b17c16da610a82cb55f6b0477d1a902134b24a455b8b3 \
-    --hash=sha256:b6a85871a79d2e3b22d2d1b94ac2824226a63c6b741c88f7ae975f18b6778374
+colorama==0.4.6 \
+    --hash=sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44 \
+    --hash=sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6
+    # via multiple-inputs-example (pyproject.toml)
+iniconfig==2.3.0 \
+    --hash=sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730 \
+    --hash=sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12
     # via pytest
-packaging==24.1 \
-    --hash=sha256:026ed72c8ed3fcce5bf8950572258698927fd1dbda10a5e981cdf0ac37f4f002 \
-    --hash=sha256:5b8f2217dbdbd2f7f384c41c628544e6d52f2d0f53c6d0c3ea61aa5d1d7ff124
+packaging==26.2 \
+    --hash=sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e \
+    --hash=sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661
     # via pytest
-pluggy==1.5.0 \
-    --hash=sha256:2cffa88e94fdc978c4c574f15f9e59b7f4201d439195c3715ca9e2486f1d0cf1 \
-    --hash=sha256:44e1ad92c8ca002de6377e165f3e0f1be63266ab4d554740532335b9d75ea669
+pluggy==1.6.0 \
+    --hash=sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3 \
+    --hash=sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746
     # via pytest
 pytest==8.2.2 \
     --hash=sha256:c434598117762e2bd304e526244f67bf66bbd7b5d6cf22138be51ff661980343 \

--- a/readme.md
+++ b/readme.md
@@ -41,6 +41,7 @@ Additionally, you can specify the following optional args:
 - `python_platform`: the `uv pip compile` compatible `--python-platform` value to pass to uv
 - `args`: override the default arguments passed to uv (`--generate-hashes`, `--emit-index-url` and `--no-strip-extras`)
 - `data`: pass additional files to be present when generating and testing requirements txt files (see also [examples/multiple-inputs](examples/multiple-inputs/))
+- `extra_srcs`: pass additional input files positionally to `uv pip compile` alongside `requirements_in` (see also [examples/multiple-inputs](examples/multiple-inputs/))
 - `tags`: tags to apply to the test target
 - `target_compatible_with`: restrict targets to running on the specified Bazel platform
 - `requirements_overrides`: a label for the file that is used to override dependencies (passed to uv via `--overrides`)

--- a/uv/pip.bzl
+++ b/uv/pip.bzl
@@ -9,6 +9,7 @@ def pip_compile(
         requirements_in = None,
         requirements_overrides = None,
         requirements_txt = None,
+        extra_srcs = None,
         target_compatible_with = None,
         python_platform = None,
         universal = False,
@@ -29,6 +30,8 @@ def pip_compile(
             May also be provided as a list of strings which represent the requirements file lines.
         requirements_overrides: (optional, default None) a label for the file that is used to override dependencies.
         requirements_txt: (optional, default "//:requirements.txt") a label for the requirements.txt file.
+        extra_srcs: (optional) additional input files to pass positionally to `uv pip compile` alongside
+            requirements_in (e.g. a `pyproject.toml`, which cannot be `-r`-referenced).
         python_platform: (optional) a uv pip compile compatible value for --python-platform.
         universal: (optional, default False) use uv's `--universal` option
         target_compatible_with: (optional) specify that a particular target is compatible only with certain
@@ -69,6 +72,7 @@ def pip_compile(
         requirements_in = requirements_in,
         requirements_overrides = requirements_overrides,
         requirements_txt = requirements_txt,
+        extra_srcs = extra_srcs or [],
         python_platform = python_platform,
         universal = universal,
         target_compatible_with = target_compatible_with,
@@ -92,6 +96,7 @@ def pip_compile(
         requirements_in = requirements_in,
         requirements_overrides = requirements_overrides,
         requirements_txt = requirements_txt,
+        extra_srcs = extra_srcs or [],
         python_platform = python_platform or "",
         universal = universal,
         target_compatible_with = target_compatible_with,

--- a/uv/private/pip.bzl
+++ b/uv/private/pip.bzl
@@ -16,6 +16,7 @@ _COMMON_ATTRS = {
     "requirements_in": attr.label(mandatory = True, allow_single_file = True),
     "requirements_overrides": attr.label(mandatory = False, allow_single_file = True),
     "requirements_txt": attr.label(mandatory = True, allow_single_file = True),
+    "extra_srcs": attr.label_list(allow_files = True),
     "python_platform": attr.string(),
     "universal": attr.bool(),
     "py3_runtime": attr.label(),
@@ -64,13 +65,18 @@ def _uv_pip_compile(
     if ctx.attr.requirements_overrides:
         args.append("--overrides={overrides_file}".format(overrides_file = ctx.file.requirements_overrides.short_path))
 
+    all_srcs = [ctx.file.requirements_in] + ctx.files.extra_srcs
+    requirements_in_files = " \\\n    ".join(
+        ['"{}"'.format(f.short_path) for f in all_srcs],
+    )
+
     ctx.actions.expand_template(
         template = template,
         output = executable,
         substitutions = {
             "{{uv}}": ctx.executable._uv.short_path,
             "{{args}}": " \\\n    ".join(args),
-            "{{requirements_in}}": ctx.file.requirements_in.short_path,
+            "{{requirements_in_files}}": requirements_in_files,
             "{{requirements_txt}}": ctx.file.requirements_txt.short_path,
             "{{compile_command}}": compile_command,
         },
@@ -80,7 +86,7 @@ def _runfiles(ctx):
     py3_runtime = _python_runtime(ctx)
     overrides_file = [ctx.file.requirements_overrides] if ctx.attr.requirements_overrides else []
     runfiles = ctx.runfiles(
-        files = [ctx.file.requirements_in, ctx.file.requirements_txt] + overrides_file + ctx.files.data,
+        files = [ctx.file.requirements_in, ctx.file.requirements_txt] + ctx.files.extra_srcs + overrides_file + ctx.files.data,
         transitive_files = py3_runtime.files,
     )
     runfiles = runfiles.merge(ctx.attr._uv[0].default_runfiles)

--- a/uv/private/pip_compile.sh
+++ b/uv/private/pip_compile.sh
@@ -3,11 +3,10 @@
 set -euo pipefail
 
 # inputs from Bazel
-REQUIREMENTS_IN="{{requirements_in}}"
 REQUIREMENTS_TXT="{{requirements_txt}}"
 
 {{uv}} pip compile \
     {{args}} \
     --output-file="$REQUIREMENTS_TXT" \
-    "$REQUIREMENTS_IN" \
+    {{requirements_in_files}} \
     "$@"

--- a/uv/private/pip_compile_test.sh
+++ b/uv/private/pip_compile_test.sh
@@ -3,7 +3,6 @@
 set -euo pipefail
 
 # inputs from Bazel
-REQUIREMENTS_IN="{{requirements_in}}"
 REQUIREMENTS_TXT="{{requirements_txt}}"
 COMPILE_COMMAND="{{compile_command}}"
 
@@ -17,7 +16,7 @@ cp "$REQUIREMENTS_TXT" "$updated_file"
     --no-cache \
     {{args}} \
     --output-file="$updated_file" \
-    "$REQUIREMENTS_IN"
+    {{requirements_in_files}}
 
 # check files match
 DIFF="$(diff "$REQUIREMENTS_TXT" "$updated_file" || true)"


### PR DESCRIPTION
## Motivation

`pip_compile` accepts a single `requirements_in` file but `uv pip compile` itself accepts multiple positional inputs. This is the only way to combine multiple `pyproject.toml` files into one lockfile, since `pyproject.toml` has no `-r` directive — `data` only adds files to runfiles, it doesn't pass them to uv.

## What changed

- New `extra_srcs` attribute (`label_list`) on both `pip_compile` and `pip_compile_test`, forwarded by the public macro and added to runfiles.
- `pip_compile.sh` / `pip_compile_test.sh` now receive a pre-quoted `{{requirements_in_files}}` substitution (the primary `requirements_in` followed by every `extra_srcs` entry) in place of the old single `$REQUIREMENTS_IN` variable.
- `examples/multiple-inputs` extended: a 4-line `pyproject.toml` (depending on `colorama`) and one line in `BUILD.bazel` (`extra_srcs = ["//:pyproject.toml"]`). The auto-registered diff test exercises the new attribute on every CI run.
- One readme bullet, two-line docstring entry.

## Alternatives considered

- **Reuse `data`.** `data` only populates runfiles; it doesn't append paths to the `uv pip compile` command line, so multi-pyproject.toml composition isn't possible with it.
- **Reuse `requirements_in` as a list of labels.** `requirements_in` already accepts a list of *strings* with different semantics (inline requirement lines written to a generated file). Overloading it with a third meaning would be confusing.
- **Generate a wrapper requirements.in that `-r`'s the others.** Doesn't work for `pyproject.toml`, which has no `-r` directive.

## Testing

- `examples/multiple-inputs` now combines `requirements_in` (click), `data`+`-r` (pytest via `requirements.test.in`), and `extra_srcs` (colorama via `pyproject.toml`); `requirements.txt` is regenerated and the diff test passes under the existing CI matrix entry.
- No new CI matrix row needed.

Happy to rename the attribute (`additional_inputs`, `extra_requirements_in`, etc.) if a different name fits better.